### PR TITLE
Use builtins.filterSource instead of fileset API for local package sources

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -9,11 +9,8 @@ let
     attrNames
     mapAttrs
     genericClosure
-    pathExists
     ;
   lockSchemaVersion = 1;
-
-  optionalFile = filepath: if pathExists filepath then [ filepath ] else [ ];
 
 in
 {
@@ -153,16 +150,10 @@ in
                   name = goPackagePath;
 
                   # Create a union of all required local sources
-                  src = lib.fileset.toSource {
-                    root = rootDir;
-                    fileset = (
-                      lib.fileset.unions (
-                        (optionalFile (rootDir + "/go.mod"))
-                        ++ (optionalFile (rootDir + "/go.work"))
-                        ++ map (dir: rootDir + dir) dirs
-                      )
-                    );
-                  };
+                  src = lib.sources.sourceByGlobs rootDir [
+                    "go.mod"
+                    "go.work.sum"
+                  ] ++ map (dir: "${dir}/**") dirs;
 
                   # Only build the current Go package
                   env.goBuildPackages = goPackagePath + "/...";

--- a/lib.nix
+++ b/lib.nix
@@ -150,10 +150,10 @@ in
                   name = goPackagePath;
 
                   # Create a union of all required local sources
-                  src = lib.sources.sourceByGlobs rootDir [
+                  src = lib.sources.sourceByGlobs rootDir ([
                     "go.mod"
                     "go.work.sum"
-                  ] ++ map (dir: "${dir}/**") dirs;
+                  ] ++ map (dir: "${dir}/**") dirs);
 
                   # Only build the current Go package
                   env.goBuildPackages = goPackagePath + "/...";


### PR DESCRIPTION
The fileset library is quite slow & allocates a lot of memory.

On a test module with 47 packages in a private repository these are the performance numbers observed:

- `after`
```json
{
  "cpuTime": 0.8548020124435425,
  "envs": {
    "bytes": 30595216,
    "elements": 2160513,
    "number": 1663889
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 154765680
  },
  "list": {
    "bytes": 3707256,
    "concats": 70997,
    "elements": 463407
  },
  "nrAvoided": 1766805,
  "nrExprs": 792722,
  "nrFunctionCalls": 1581789,
  "nrLookups": 637093,
  "nrOpUpdateValuesCopied": 2343330,
  "nrOpUpdates": 179146,
  "nrPrimOpCalls": 750587,
  "nrThunks": 1788793,
  "sets": {
    "bytes": 57132440,
    "elements": 3308087,
    "number": 175127
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 707113,
    "number": 62302
  },
  "time": {
    "cpu": 0.8548020124435425,
    "gc": 0.01,
    "gcFraction": 0.011698615415532231
  },
  "values": {
    "bytes": 38270000,
    "number": 2391875
  }
}
```

- `before`
```json
{
  "cpuTime": 0.939765989780426,
  "envs": {
    "bytes": 33301400,
    "elements": 2333111,
    "number": 1829564
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 164830608
  },
  "list": {
    "bytes": 4190464,
    "concats": 74006,
    "elements": 523808
  },
  "nrAvoided": 2023460,
  "nrExprs": 792635,
  "nrFunctionCalls": 1728192,
  "nrLookups": 663377,
  "nrOpUpdateValuesCopied": 2343786,
  "nrOpUpdates": 179434,
  "nrPrimOpCalls": 902783,
  "nrThunks": 1929008,
  "sets": {
    "bytes": 57700800,
    "elements": 3334788,
    "number": 181008
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 707099,
    "number": 62300
  },
  "time": {
    "cpu": 0.939765989780426,
    "gc": 0.011,
    "gcFraction": 0.011705041595057215
  },
  "values": {
    "bytes": 41625136,
    "number": 2601571
  }
}
```